### PR TITLE
Fix incorrect TwitterAds::Cursor#count on objects with non-standard API responses

### DIFF
--- a/lib/twitter-ads/cursor.rb
+++ b/lib/twitter-ads/cursor.rb
@@ -28,6 +28,16 @@ module TwitterAds
       self
     end
 
+    # Exhausts the Cursor then returns the last object in the collection.
+    #
+    # @return [Object] The last object in the collection.
+    #
+    # @since 0.2.0
+    def last
+      each {}
+      @collection.last
+    end
+
     # Method to fetch the next page only.
     #
     # @return [Array] A collection containing the next page of objects.
@@ -71,7 +81,7 @@ module TwitterAds
     #
     # @since 0.1.0
     def count
-      @total_count
+      @total_count || @collection.size
     end
     alias_method :size, :count
 
@@ -100,7 +110,7 @@ module TwitterAds
 
     def from_response(response)
       @next_cursor = response.body[:next_cursor]
-      @total_count ||= response.body[:total_count].to_i
+      @total_count = response.body[:total_count].to_i if response.body.key?(:total_count)
       response.body.fetch(:data, []).each do |object|
         if @klass && @klass.method_defined?(:from_response)
           @collection << @klass.new(

--- a/spec/twitter-ads/cursor_spec.rb
+++ b/spec/twitter-ads/cursor_spec.rb
@@ -1,0 +1,66 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+require 'spec_helper'
+
+describe TwitterAds::Cursor do
+
+  before(:each) do
+    stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
+    stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+    stub_fixture(:get, :campaigns_all, "#{ADS_API}/accounts/2iqph/campaigns")
+    stub_fixture(:get, :app_lists_all, "#{ADS_API}/accounts/2iqph/app_lists")
+  end
+
+  let(:client) do
+    Client.new(
+      Faker::Lorem.characters(15),
+      Faker::Lorem.characters(40),
+      "123456-#{Faker::Lorem.characters(40)}",
+      Faker::Lorem.characters(40)
+    )
+  end
+
+  let(:account) { client.accounts.first }
+
+  describe '#last' do
+
+    let(:cursor) { account.campaigns }
+
+    it 'exhausts the Cursor and returns the last object' do
+      expect(cursor).to receive(:each).and_call_original
+      result = cursor.last
+      expect(result).not_to be_nil
+      expect(result).to eq(cursor.instance_variable_get('@collection').last)
+      expect(cursor.exhausted?).to be true
+    end
+
+  end
+
+  describe '#count' do
+
+    context 'for non-standard responses' do
+
+      let(:cursor) { account.app_lists }
+
+      it 'returns the correct count for non-standard responses' do
+        expect(cursor.count).to eq(3)
+        expect(cursor.instance_variable_get('@total_count')).to be_nil
+        expect(cursor.exhausted?).to be true
+      end
+
+    end
+
+    context 'for standard responses' do
+
+      let(:cursor) { account.campaigns }
+
+      it 'returns the correct count for non-standard responses' do
+        expect(cursor.instance_variable_get('@total_count')).not_to be_nil
+        expect(cursor.count).to eq(cursor.instance_variable_get('@total_count'))
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
GET /app_lists responses don't actually implement a cursor and have a non-standard API response. We'd like to expose app lists in a seamless way in the SDK. 

For the most part `TwitterAds::Cursor` handles this fine, but we need to update `TwitterAds::Cursor#count` to handle this situation where `next_cursor` and `count` params are not present in the API response.

**Steps to Reproduce:**
```ruby
account = client.accounts.first
account.app_lists
```

**Actual:**
```ruby
#<TwitterAds::Cursor:0x70298042846660 count=0 fetched=1 exhausted=true>
```

**Expected:**
```ruby
#<TwitterAds::Cursor:0x70298042846660 count=1 fetched=1 exhausted=true>
```

**Related To:**
#14 Implement AppList Support