### PR TITLE
Implement support for Organic Tweet Analytics

### DIFF
--- a/lib/twitter-ads/resources/analytics.rb
+++ b/lib/twitter-ads/resources/analytics.rb
@@ -4,11 +4,10 @@ module TwitterAds
   module Analytics
 
     CLASS_ID_MAP = {
-      'TwitterAds::PromotedTweet' => :tweet_ids,
-      'TwitterAds::LineItem'      => :line_item_ids
-    }
-
-    private_constant :CLASS_ID_MAP
+      'TwitterAds::LineItem'     => :line_item_ids,
+      'TwitterAds::OrganicTweet' => :tweet_ids,
+      'TwitterAds::Tweet'        => :tweet_ids
+    } # @api private
 
     def self.included(klass)
       klass.send :include, InstanceMethods
@@ -76,7 +75,7 @@ module TwitterAds
           granularity: granularity.to_s.upcase
         }
         params[:segmentation_type] = segmentation_type.to_s.upcase if segmentation_type
-        params[CLASS_ID_MAP[name]] = ids.join(',')
+        params[TwitterAds::Analytics::CLASS_ID_MAP[name]] = ids.join(',')
 
         resource = self::RESOURCE_STATS % { account_id: account.id }
         response = Request.new(account.client, :get, resource, params: params).perform

--- a/lib/twitter-ads/tweet.rb
+++ b/lib/twitter-ads/tweet.rb
@@ -3,8 +3,12 @@
 module TwitterAds
   module Tweet
 
+    # cannot instaniate Tweet, only including class methods for stats
+    extend TwitterAds::Analytics::ClassMethods
+
     RESOURCE_COLLECTION = '/0/accounts/%{account_id}/tweet/preview' # @api private
-    RESOURCE = '/0/accounts/%{account_id}/tweet/preview/%{id}' # @api private
+    RESOURCE_STATS      = '/0/stats/accounts/%{account_id}/organic_tweets' # @api private
+    RESOURCE            = '/0/accounts/%{account_id}/tweet/preview/%{id}' # @api private
 
     class << self
 

--- a/spec/twitter-ads/tweet_spec.rb
+++ b/spec/twitter-ads/tweet_spec.rb
@@ -28,7 +28,7 @@ describe TwitterAds::Tweet do
       stub_fixture(:get, :tweet_preview, /#{resource_collection}.*/)
     end
 
-    context 'with an id value specified' do
+    context 'with an existing tweet id' do
 
       it 'successfully returns a preview of the specified tweet' do
         params = { id: 634798319504617472 }


### PR DESCRIPTION
**Changes Needed:**
- [x] Implement Tweet#stats()
- [ ] ~~Test Coverage~~
- [x] Documentation

**Related documentation:**
https://dev.twitter.com/ads/reference/get/stats/accounts/%3Aaccount_id/organic_tweets
https://dev.twitter.com/ads/reference/get/stats/accounts/%3Aaccount_id/organic_tweets/%3Atweet_id