### PR TITLE
[feat] sandbox mode + basic request logging

### DIFF
--- a/lib/twitter-ads/client.rb
+++ b/lib/twitter-ads/client.rb
@@ -8,7 +8,8 @@ module TwitterAds
     attr_accessor :consumer_key,
                   :consumer_secret,
                   :access_token,
-                  :access_token_secret
+                  :access_token_secret,
+                  :options
 
     # Creates a new Ads API client instance.
     #
@@ -16,15 +17,17 @@ module TwitterAds
     # @param consumer_secret nil [String] The application consumer secret value.
     # @param access_token nil [String] The access token value.
     # @param access_token_secret nil [String] The access token secret value.
+    # @param opts [Hash] An optional Hash of extended options.
     #
     # @since 0.1.0
     #
     # @return [Client] The newly created client instance.
-    def initialize(consumer_key, consumer_secret, access_token, access_token_secret)
+    def initialize(consumer_key, consumer_secret, access_token, access_token_secret, opts={})
       @consumer_key        = consumer_key
       @consumer_secret     = consumer_secret
       @access_token        = access_token
       @access_token_secret = access_token_secret
+      @options             = opts
       validate
       self
     end

--- a/lib/twitter-ads/client.rb
+++ b/lib/twitter-ads/client.rb
@@ -22,7 +22,7 @@ module TwitterAds
     # @since 0.1.0
     #
     # @return [Client] The newly created client instance.
-    def initialize(consumer_key, consumer_secret, access_token, access_token_secret, opts={})
+    def initialize(consumer_key, consumer_secret, access_token, access_token_secret, opts = {})
       @consumer_key        = consumer_key
       @consumer_secret     = consumer_secret
       @access_token        = access_token


### PR DESCRIPTION
Added support for 2 new options for TwitterAds::Client:
:sandbox = use sandbox api (logging enabled by default in sandbox mode)
:enable_logger = basic request logging (regardless of sandbox mode)

fixes #32 