### PR TITLE
Changes tweet_id to tweet_ids. Updated website card properties. Adds …

### DIFF
--- a/lib/twitter-ads/campaign.rb
+++ b/lib/twitter-ads/campaign.rb
@@ -9,7 +9,7 @@ module TwitterAds
 
     attr_reader :account
 
-    property :id, read_only: true
+    property :id
     property :reasons_not_servable, read_only: true
     property :servable, read_only: true
     property :deleted, type: :bool, read_only: true

--- a/lib/twitter-ads/creative/promoted_tweet.rb
+++ b/lib/twitter-ads/creative/promoted_tweet.rb
@@ -19,7 +19,7 @@ module TwitterAds
       property :deleted, type: :bool, read_only: true
 
       property :line_item_id
-      property :tweet_id
+      property :tweet_ids
       property :paused, type: :bool
 
       RESOURCE_COLLECTION = '/0/accounts/%{account_id}/promoted_tweets' # @api private

--- a/lib/twitter-ads/creative/website_card.rb
+++ b/lib/twitter-ads/creative/website_card.rb
@@ -19,17 +19,9 @@ module TwitterAds
 
       property :name
       property :image_media_id
-      property :cta
-      property :fallback_url
-      property :privacy_policy_url
-      property :title
-      property :submit_url
-      property :submit_method
-      property :custom_destination_url
-      property :custom_destination_text
-      property :custom_key_screen_name
-      property :custom_key_name
-      property :custom_key_email
+      property :website_cta
+      property :website_url
+      property :website_title
 
       RESOURCE_COLLECTION = '/0/accounts/%{account_id}/cards/website' # @api private
       RESOURCE            = '/0/accounts/%{account_id}/cards/website/%{id}' # @api private

--- a/lib/twitter-ads/resources/dsl.rb
+++ b/lib/twitter-ads/resources/dsl.rb
@@ -20,6 +20,7 @@ module TwitterAds
       #
       # @since 0.1.0
       def from_response(object)
+        object = object[0] if object.is_a? Array
         self.class.properties.each do |name, type|
           value = nil
           if type == :time && object[name] && !object[name].empty?

--- a/spec/twitter-ads/creative/promoted_tweet_spec.rb
+++ b/spec/twitter-ads/creative/promoted_tweet_spec.rb
@@ -23,7 +23,7 @@ describe TwitterAds::Creative::PromotedTweet do
   # check model properties
   subject { described_class.new(account) }
   read  = %w(id approval_status created_at updated_at deleted)
-  write = %w(line_item_id tweet_id paused)
+  write = %w(line_item_id tweet_ids paused)
   include_examples 'object property check', read, write
 
 end


### PR DESCRIPTION
…support for array like responses. Makes campaign ID writable so we can update them

Pluralized the tweet_ids property

Sets the properties for website card

Adds fix for response data comming as an array, this should be fixed server side anyways

Fixes broken tests

Making campaign ID writable so we can update campaigns