### PR TITLE
Error not reported on saving promoted tweet object

### DIFF
--- a/lib/twitter-ads/creative/website_card.rb
+++ b/lib/twitter-ads/creative/website_card.rb
@@ -18,18 +18,10 @@ module TwitterAds
       property :updated_at, type: :time, read_only: true
 
       property :name
+      property :website_title
+      property :website_url
+      property :website_cta
       property :image_media_id
-      property :cta
-      property :fallback_url
-      property :privacy_policy_url
-      property :title
-      property :submit_url
-      property :submit_method
-      property :custom_destination_url
-      property :custom_destination_text
-      property :custom_key_screen_name
-      property :custom_key_name
-      property :custom_key_email
 
       RESOURCE_COLLECTION = '/0/accounts/%{account_id}/cards/website' # @api private
       RESOURCE            = '/0/accounts/%{account_id}/cards/website/%{id}' # @api private

--- a/lib/twitter-ads/error.rb
+++ b/lib/twitter-ads/error.rb
@@ -4,17 +4,24 @@ module TwitterAds
 
   class Error < StandardError
 
-    attr_reader :response, :details
+    attr_reader :code, :headers, :response, :details
 
-    def initialize(object)
-      @response = object
-      @details  = object.body[:errors] if object.body[:errors]
+    def initialize(*args)
+      if args.size == 1 && args[0].respond_to?(:body) && args[0].respond_to?(:code)
+        @response = args[0]
+        @code     = args[0].code
+        @details  = args[0].body[:errors] if args[0].body[:errors]
+      elsif args.size == 3
+        @response = args[0]
+        @details  = args[1]
+        @code     = args[2]
+      end
       self
     end
 
     def inspect
       str = "#<#{self.class.name}:0x#{object_id}"
-      str << " code=#{@response.code}" if @response && @response.code
+      str << " code=#{@code}" if @code
       str << " details=\"#{@details}\"" if @details
       str << '>'
     end

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end

--- a/spec/twitter-ads/creative/app_download_card_spec.rb
+++ b/spec/twitter-ads/creative/app_download_card_spec.rb
@@ -1,0 +1,43 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+require 'spec_helper'
+
+describe TwitterAds::Creative::AppDownloadCard do
+
+  before(:each) do
+    stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
+    stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+  end
+
+  let(:client) do
+    Client.new(
+      Faker::Lorem.characters(15),
+      Faker::Lorem.characters(40),
+      "123456-#{Faker::Lorem.characters(40)}",
+      Faker::Lorem.characters(40)
+    )
+  end
+
+  let(:account) { client.accounts.first }
+
+  # check model properties
+  subject { described_class.new(account) }
+  read  = %w(id preview_url created_at updated_at deleted)
+
+  write = %w(
+    name
+    app_country_code
+    iphone_app_id
+    iphone_deep_link
+    ipad_app_id
+    ipad_deep_link
+    googleplay_app_id
+    googleplay_deep_link
+    app_cta
+    custom_icon_media_id
+    custom_app_description
+  )
+
+  include_examples 'object property check', read, write
+
+end

--- a/spec/twitter-ads/creative/image_app_download_card_spec.rb
+++ b/spec/twitter-ads/creative/image_app_download_card_spec.rb
@@ -1,0 +1,42 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+require 'spec_helper'
+
+describe TwitterAds::Creative::ImageAppDownloadCard do
+
+  before(:each) do
+    stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
+    stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+  end
+
+  let(:client) do
+    Client.new(
+      Faker::Lorem.characters(15),
+      Faker::Lorem.characters(40),
+      "123456-#{Faker::Lorem.characters(40)}",
+      Faker::Lorem.characters(40)
+    )
+  end
+
+  let(:account) { client.accounts.first }
+
+  # check model properties
+  subject { described_class.new(account) }
+  read  = %w(id preview_url created_at updated_at deleted)
+
+  write = %w(
+    name
+    app_country_code
+    iphone_app_id
+    iphone_deep_link
+    ipad_app_id
+    ipad_deep_link
+    googleplay_app_id
+    googleplay_deep_link
+    app_cta
+    wide_app_image_media_id
+  )
+
+  include_examples 'object property check', read, write
+
+end

--- a/spec/twitter-ads/creative/lead_gen_card_spec.rb
+++ b/spec/twitter-ads/creative/lead_gen_card_spec.rb
@@ -1,0 +1,45 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+require 'spec_helper'
+
+describe TwitterAds::Creative::LeadGenCard do
+
+  before(:each) do
+    stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
+    stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+  end
+
+  let(:client) do
+    Client.new(
+      Faker::Lorem.characters(15),
+      Faker::Lorem.characters(40),
+      "123456-#{Faker::Lorem.characters(40)}",
+      Faker::Lorem.characters(40)
+    )
+  end
+
+  let(:account) { client.accounts.first }
+
+  # check model properties
+  subject { described_class.new(account) }
+  read  = %w(id preview_url created_at updated_at deleted)
+
+  write = %w(
+    name
+    image_media_id
+    cta
+    fallback_url
+    privacy_policy_url
+    title
+    submit_url
+    submit_method
+    custom_destination_url
+    custom_destination_text
+    custom_key_screen_name
+    custom_key_name
+    custom_key_email
+  )
+
+  include_examples 'object property check', read, write
+
+end

--- a/spec/twitter-ads/creative/promoted_tweet_spec.rb
+++ b/spec/twitter-ads/creative/promoted_tweet_spec.rb
@@ -26,4 +26,20 @@ describe TwitterAds::Creative::PromotedTweet do
   write = %w(line_item_id tweet_id paused)
   include_examples 'object property check', read, write
 
+  describe '#save' do
+
+    it 'raises a client error when missing tweet_id' do
+      expect(subject).to receive(:validate).and_call_original
+      subject.line_item_id = '12345'
+      expect { subject.save }.to raise_error(TwitterAds::ClientError)
+    end
+
+    it 'raises a client error when missing line_item_id' do
+      expect(subject).to receive(:validate).and_call_original
+      subject.tweet_id = 99999999999999999999
+      expect { subject.save }.to raise_error(TwitterAds::ClientError)
+    end
+
+  end
+
 end

--- a/spec/twitter-ads/creative/website_card_spec.rb
+++ b/spec/twitter-ads/creative/website_card_spec.rb
@@ -1,0 +1,29 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+require 'spec_helper'
+
+describe TwitterAds::Creative::WebsiteCard do
+
+  before(:each) do
+    stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
+    stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+  end
+
+  let(:client) do
+    Client.new(
+      Faker::Lorem.characters(15),
+      Faker::Lorem.characters(40),
+      "123456-#{Faker::Lorem.characters(40)}",
+      Faker::Lorem.characters(40)
+    )
+  end
+
+  let(:account) { client.accounts.first }
+
+  # check model properties
+  subject { described_class.new(account) }
+  read  = %w(id preview_url created_at updated_at deleted)
+  write = %w(name website_title website_url website_cta image_media_id)
+  include_examples 'object property check', read, write
+
+end


### PR DESCRIPTION
May or may not be related to Issue #39 - Way to reproduce

```
account = CLIENT.accounts.first
# create your campaign
campaign = TwitterAds::Campaign.new(account)
campaign.funding_instrument_id = account.funding_instruments.first.id
campaign.daily_budget_amount_local_micro = 1_000_000
campaign.name       = 'my first campaign'
campaign.paused     = true
campaign.start_time = Time.now.utc
campaign.save

# create a line item for the campaign
line_item = TwitterAds::LineItem.new(account)
line_item.campaign_id            = campaign.id
line_item.name                   = 'my first ad'
line_item.product_type           = TwitterAds::Product::PROMOTED_TWEETS
line_item.placements             = [TwitterAds::Placement::ALL_ON_TWITTER]
line_item.objective              = TwitterAds::Objective::TWEET_ENGAGEMENTS
line_item.bid_amount_local_micro = 10_000
line_item.paused                 = true
line_item.save

# promote the tweet using our line item
promoted_tweet = TwitterAds::Creative::PromotedTweet.new(account)
promoted_tweet.line_item_id = line_item.id
promoted_tweet.save
```

I got this -: 
```
NoMethodError: undefined method `[]' for nil:NilClass
from /Users/pratikbothra/.rvm/gems/ruby-2.2.2/gems/twitter-ads-0.2.4/lib/twitter-ads/resources/dsl.rb:30:in `block in from_response'
```
Instead of the error that tweet_id is missing