### PR TITLE
[bug] resolving issue with boolean values in #to_params

### DIFF
--- a/lib/twitter-ads/resources/dsl.rb
+++ b/lib/twitter-ads/resources/dsl.rb
@@ -42,7 +42,7 @@ module TwitterAds
         params = {}
         self.class.properties.each do |name, type|
           value = instance_variable_get("@#{name}") || send(name)
-          next unless value
+          next if value.nil?
           if type == :time
             params[name] = value.iso8601
           elsif type == :bool

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
Resolves an issue where `DSL::to_params` was handling boolean values incorrectly.

**Example:**
```ruby
line_item.paused = false
line_item.to_params
```

**Expected Result:**
```ruby
{ paused: false }
```

**Actual Result:**
```ruby
{ paused: true }
```