### PR TITLE
add targeting_criteria/tv_markets

### DIFF
--- a/lib/twitter-ads.rb
+++ b/lib/twitter-ads.rb
@@ -36,6 +36,8 @@ require 'twitter-ads/reach_estimate'
 require 'twitter-ads/targeting_criteria'
 require 'twitter-ads/tweet'
 
+require 'twitter-ads/targeting_criteria/tv_market'
+
 require 'twitter-ads/creative/app_download_card'
 require 'twitter-ads/creative/image_app_download_card'
 require 'twitter-ads/creative/lead_gen_card'

--- a/lib/twitter-ads/targeting_criteria.rb
+++ b/lib/twitter-ads/targeting_criteria.rb
@@ -28,9 +28,5 @@ module TwitterAds
       @account = account
       self
     end
-
-    def tv_markets(opts = {})
-      TwitterAds::TvMarket.all @account, opts
-    end
   end
 end

--- a/lib/twitter-ads/targeting_criteria.rb
+++ b/lib/twitter-ads/targeting_criteria.rb
@@ -29,5 +29,8 @@ module TwitterAds
       self
     end
 
+    def tv_markets(opts = {})
+      TwitterAds::TvMarket.all @account, opts
+    end
   end
 end

--- a/lib/twitter-ads/targeting_criteria/tv_market.rb
+++ b/lib/twitter-ads/targeting_criteria/tv_market.rb
@@ -1,0 +1,21 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+module TwitterAds
+  class TvMarket
+
+    include TwitterAds::DSL
+    include TwitterAds::Resource
+
+    property :id, read_only: true
+    property :name, read_only: true
+    property :locale, read_only: true
+    property :country_code, read_only: true
+
+    RESOURCE_COLLECTION = '/0/targeting_criteria/tv_markets' # @api private
+
+    def initialize(account)
+      @account = account
+      self
+    end
+  end
+end


### PR DESCRIPTION
I want to add api of targeting_criteria.
this is minimum commit for confirmation of policy.

# api document
https://dev.twitter.com/ads/reference/get/targeting_criteria/tv_markets

# usage
```
twitter-ads v0.3.0 >> account = CLIENT.accounts.first
twitter-ads v0.3.0 >> TwitterAds::TvMarket.all account
=> #<TwitterAds::Cursor:0x70280258158740 count=17 fetched=17 exhausted=true>
```