### PR TITLE
add targeting_criteria/tv_markets

### DIFF
--- a/lib/twitter-ads.rb
+++ b/lib/twitter-ads.rb
@@ -41,8 +41,6 @@ require 'twitter-ads/video'
 
 require 'twitter-ads/targeting_criteria/tv_market.rb'
 
-require 'twitter-ads/targeting_criteria/tv_market.rb'
-
 require 'twitter-ads/creative/app_download_card'
 require 'twitter-ads/creative/image_app_download_card'
 require 'twitter-ads/creative/image_conversation_card'

--- a/lib/twitter-ads.rb
+++ b/lib/twitter-ads.rb
@@ -39,6 +39,8 @@ require 'twitter-ads/targeting_criteria'
 require 'twitter-ads/tweet'
 require 'twitter-ads/video'
 
+require 'twitter-ads/targeting_criteria/tv_market.rb'
+
 require 'twitter-ads/creative/app_download_card'
 require 'twitter-ads/creative/image_app_download_card'
 require 'twitter-ads/creative/image_conversation_card'

--- a/lib/twitter-ads/targeting_criteria/tv_market.rb
+++ b/lib/twitter-ads/targeting_criteria/tv_market.rb
@@ -1,0 +1,21 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+module TwitterAds
+  class TvMarket
+
+    include TwitterAds::DSL
+    include TwitterAds::Resource
+
+    property :id, read_only: true
+    property :name, read_only: true
+    property :locale, read_only: true
+    property :country_code, read_only: true
+
+    RESOURCE_COLLECTION = '/0/targeting_criteria/tv_markets' # @api private
+
+    def initialize(account)
+      @account = account
+      self
+    end
+  end
+end


### PR DESCRIPTION
I want to add api of targeting_criteria.
this is minimum commit for confirmation of policy.

exclude unused commit from https://github.com/twitterdev/twitter-ruby-ads-sdk/pull/46

# api document
https://dev.twitter.com/ads/reference/get/targeting_criteria/tv_markets

# usage
```
twitter-ads v0.3.0 >> account = CLIENT.accounts.first
twitter-ads v0.3.0 >> TwitterAds::TvMarket.all account
=> #<TwitterAds::Cursor:0x70280258158740 count=17 fetched=17 exhausted=true>
```