### PR TITLE
Support for TON uploads less than 1 MB, plus a minor documentation fix

### DIFF
--- a/lib/twitter-ads/tailored_audience.rb
+++ b/lib/twitter-ads/tailored_audience.rb
@@ -53,7 +53,7 @@ module TwitterAds
       # Creates a new tailored audience.
       #
       # @example
-      #   audience = TailoredAudience.new(account, '/path/to/file', 'my list', 'EMAIL')
+      #   audience = TailoredAudience.create(account, '/path/to/file', 'my list', 'EMAIL')
       #
       # @param account [Account] The account object instance.
       # @param file_path [String] The path to the file to be uploaded.


### PR DESCRIPTION
We plan to create tailored audiences with less than 1 MB of data but with still more than 500 targetable users (1 MB == 15385 lines of SHA256 hashes).  I've added support for this to the library.

I also fixed a documentation error in the comments of TailoredAudience.create.

I attempted to follow your coding standards, and it passes the tests; feel free to ask me to change anything that isn't right for you.

Thanks for the library!