### PR TITLE
Can't unset `type: :time` params on API objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem 'cucumber'
   gem 'webmock'
   gem 'codeclimate-test-reporter', platforms: :mri
+  gem 'simplecov', '0.10' # fix for breaking change in simplecov
 end
 
 group :development do

--- a/lib/twitter-ads/resources/dsl.rb
+++ b/lib/twitter-ads/resources/dsl.rb
@@ -43,6 +43,13 @@ module TwitterAds
         self.class.properties.each do |name, type|
           value = instance_variable_get("@#{name}") || send(name)
           next if value.nil?
+
+          # handles unset with empty string
+          if value.respond_to?(:strip) && value.strip == ''
+            params[name] = value.strip
+            next
+          end
+
           if type == :time
             params[name] = value.iso8601
           elsif type == :bool

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -1,5 +1,5 @@
 # Copyright (C) 2015 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
I update campaign and set end_time is nil for campaign but value end_time was not updated

```
#update campaign
campaign = account.campaigns(params[:id])
campaign.name       = params[:data][:name]
campaign.end_time = nil
campaign.save
```