### PR TITLE
Stop URL encoding statuses when previewing

### DIFF
--- a/lib/twitter-ads/campaign/tweet.rb
+++ b/lib/twitter-ads/campaign/tweet.rb
@@ -38,9 +38,6 @@ module TwitterAds
         resource = opts.key?(:id) ? RESOURCE : RESOURCE_COLLECTION
         resource = resource % { account_id: account.id, id: opts.delete(:id) }
 
-        # url encodes statuss message if present
-        opts[:status] = URI.escape(opts[:status]) if opts.key?(:status)
-
         # handles array to string conversion for media IDs
         if opts.key?(:media_ids) && opts[:media_ids].respond_to?(:join)
           opts[:media_ids] = opts[:media_ids].join(',')

--- a/spec/twitter-ads/campaign/tweet_spec.rb
+++ b/spec/twitter-ads/campaign/tweet_spec.rb
@@ -41,17 +41,9 @@ describe TwitterAds::Tweet do
 
     context 'when previewing a new tweet' do
 
-      it 'url encodes the status content' do
-        params = { status: 'Hello World!', card_id: '19v69' }
-        expect(URI).to receive(:escape).at_least(:once).and_call_original
-        result = subject.preview(account, params)
-        expect(result.size).not_to be_nil
-        expect(result).to all(include(:platform, :preview))
-      end
-
       it 'allows a single value for the media_ids param' do
         resource = "/0/accounts/#{account.id}/tweet/preview"
-        expected = { status: 'Hello%20World!', media_ids: 634458428836962304 }
+        expected = { status: 'Hello World!', media_ids: 634458428836962304 }
 
         expect(TwitterAds::Request).to receive(:new).with(
           account.client, :get, resource, params: expected).and_call_original
@@ -64,7 +56,7 @@ describe TwitterAds::Tweet do
 
       it 'allows an array of values for the media_ids param' do
         resource = "/0/accounts/#{account.id}/tweet/preview"
-        expected = { status: 'Hello%20World!', media_ids: '634458428836962304,634458428836962305' }
+        expected = { status: 'Hello World!', media_ids: '634458428836962304,634458428836962305' }
 
         expect(TwitterAds::Request).to receive(:new).with(
           account.client, :get, resource, params: expected).and_call_original


### PR DESCRIPTION
When attempting to preview a status, I observed that spaces were converted to %20 in the final preview.  I traced this down to this code which is intentionally URL encoding the status text.  I can't see why this would be necessary.  Removing this code causes no errors and causes spaces to be preserved when previewing.

Presumably there must have originally been a reason for this code.  If there was, this probably isn't the right change, but some change is necessary here.