### PR TITLE
[minor] protecting against case sensitive file extensions in ton upload

### DIFF
--- a/lib/twitter-ads/http/ton_upload.rb
+++ b/lib/twitter-ads/http/ton_upload.rb
@@ -81,10 +81,7 @@ module TwitterAds
     #
     # @return [String] The object instance detail.
     def inspect
-      str = "#<#{self.class.name}:0x#{object_id}"
-      str << " bucket=\"#{@bucket}\"" if @bucket
-      str << " file=\"#{@file_path}\"" if @file
-      str << '>'
+      "#<#{self.class.name}:0x#{object_id} bucket=\"#{@bucket}\" file=\"#{@file_path}\">"
     end
 
     private
@@ -127,7 +124,7 @@ module TwitterAds
 
     def content_type
       @content_type ||= begin
-        extension = File.extname(@file_path)
+        extension = File.extname(@file_path).downcase
         if extension == '.csv'
           'text/csv'
         elsif extension == '.tsv'

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -2,5 +2,5 @@
 # Copyright (C) 2015 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end


### PR DESCRIPTION
Small fix to prevent errors in the event that the file extension is upper cased. This is super minor since content-type would have just defaulted back to 'text/plain' but this will help ensure the correct content-type is detected.