### PR TITLE
Add missing bid_type in the list of line_item attributes

### DIFF
--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -33,6 +33,11 @@ module TwitterAds
     property :bid_amount_local_micro
     property :total_budget_amount_local_micro
 
+    # beta (not yet generally available)
+    property :advertiser_user_id
+    property :bid_type
+    property :tracking_tags
+
     RESOURCE_COLLECTION = '/0/accounts/%{account_id}/line_items'.freeze # @api private
     RESOURCE_STATS      = '/0/stats/accounts/%{account_id}/line_items'.freeze # @api private
     RESOURCE            = '/0/accounts/%{account_id}/line_items/%{id}'.freeze # @api private

--- a/lib/twitter-ads/enum.rb
+++ b/lib/twitter-ads/enum.rb
@@ -66,6 +66,12 @@ module TwitterAds
       VIEW        = 'VIEW'.freeze
     end
 
+    module BidType
+      MAX    = 'MAX'.freeze
+      AUTO   = 'AUTO'.freeze
+      TARGET = 'TARGET'.freeze
+    end
+
     module ChargeBy
       APP_CLICK   = 'APP_CLICK'.freeze
       APP_INSTALL = 'APP_INSTALL'.freeze
@@ -134,6 +140,10 @@ module TwitterAds
       ADD = 'ADD'.freeze
       REMOVE  = 'REMOVE'.freeze
       REPLACE = 'REPLACE'.freeze
+    end
+
+    module TrackingPartner
+      DOUBLE_CLICK = 'DOUBLE_CLICK'.freeze
     end
 
   end

--- a/lib/twitter-ads/resources/dsl.rb
+++ b/lib/twitter-ads/resources/dsl.rb
@@ -56,7 +56,7 @@ module TwitterAds
           elsif type == :bool
             params[name] = TwitterAds::Utils.to_bool(value)
           elsif value.is_a?(Array)
-            next if value.size < 1
+            next if value.empty?
             params[name] = value.join(',')
           else
             params[name] = value


### PR DESCRIPTION
Hello,

I noticed the bid_type is missing from the list of properties in:

https://github.com/twitterdev/twitter-ruby-ads-sdk/blob/master/lib/twitter-ads/campaign/line_item.rb

is that something done on purpose?