### PR TITLE
Updating enum.rb to include the new VIEW_3S_100PCT BidUnit

### DIFF
--- a/lib/twitter-ads/enum.rb
+++ b/lib/twitter-ads/enum.rb
@@ -81,6 +81,7 @@ module TwitterAds
       LEAD        = 'LEAD'.freeze
       LINK_CLICK  = 'LINK_CLICK'.freeze
       VIEW        = 'VIEW'.freeze
+      VIEW_3S_100PCT = 'VIEW_3S_100PCT'.freeze
     end
 
     module CreativeType

--- a/lib/twitter-ads/enum.rb
+++ b/lib/twitter-ads/enum.rb
@@ -64,6 +64,7 @@ module TwitterAds
       LEAD        = 'LEAD'.freeze
       LINK_CLICK  = 'LINK_CLICK'.freeze
       VIEW        = 'VIEW'.freeze
+      VIEW_3S_100PCT = "VIEW_3S_100PCT".freeze
     end
 
     module BidType

--- a/lib/twitter-ads/enum.rb
+++ b/lib/twitter-ads/enum.rb
@@ -64,7 +64,7 @@ module TwitterAds
       LEAD        = 'LEAD'.freeze
       LINK_CLICK  = 'LINK_CLICK'.freeze
       VIEW        = 'VIEW'.freeze
-      VIEW_3S_100PCT = "VIEW_3S_100PCT".freeze
+      VIEW_3S_100PCT = 'VIEW_3S_100PCT'.freeze
     end
 
     module BidType


### PR DESCRIPTION
**Issue Type:** Feature

**Fixes / Relates To:** https://www.apichangelog.com/changes/984bf4bd-3f81-4b38-bec0-04064692c5ba

**Changes Included:**
- Extends the bid_unit to include VIEW_3S_100PCT enumeration value

**DETAILS**
Updating the enum.rb to bring it to current: https://www.apichangelog.com/changes/984bf4bd-3f81-4b38-bec0-04064692c5ba

@brandonblack => In addition to this change, does it make sense to extend this enum to include all of https://dev.twitter.com/ads/basics/enums? Let me know your thoughts.