### PR TITLE
When calling the endpoint /stats it should be allowed to pass the hour for the :day granularity

### DIFF
--- a/lib/twitter-ads/utils.rb
+++ b/lib/twitter-ads/utils.rb
@@ -28,11 +28,8 @@ module TwitterAds
       # @api private
       # @since 0.1.0
       def to_time(time, granularity = nil)
-        return time.iso8601 unless granularity
-        if granularity == :hour
+        if [:hour, :day].include? granularity
           Time.new(time.year, time.month, time.day, time.hour).iso8601
-        elsif granularity == :day
-          Time.new(time.year, time.month, time.day).iso8601
         else
           time.iso8601
         end

--- a/spec/twitter-ads/utils_spec.rb
+++ b/spec/twitter-ads/utils_spec.rb
@@ -46,8 +46,8 @@ describe TwitterAds::Utils do
         expect(subject.to_time(time, :hour)).to eq(expected_result)
       end
 
-      it 'returns the ISO 8601 formatted string for :day rounded to the day' do
-        expected_result = Time.new(time.year, time.month, time.day).iso8601
+      it 'returns the ISO 8601 formatted string for :day rounded to the hour' do
+        expected_result = Time.new(time.year, time.month, time.day, time.hour).iso8601
         expect(subject.to_time(time, :day)).to eq(expected_result)
       end
 


### PR DESCRIPTION
**Issue Type:** Bug

**Fixes / Relates To:** https://dev.twitter.com/ads/basics/timezones (see "when using the /stats/ endpoint")

**DETAILS**
When using the /stats endpoint with "day" granularity, the iso8601 time passed should be alligned with the twitter adaccount' 00 hour