### PR TITLE
[maintenance] updating styles and verison for rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ Metrics/ParameterLists:
 Performance/Casecmp:
   Enabled: false
 
+Style/MultilineMethodCallBraceLayout:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake'
 
 group :development, :test do
   gem 'faker'
-  gem 'rubocop', '~>0.35'
+  gem 'rubocop', '0.38.0' # locked for style changes
   gem 'rspec'
   gem 'cucumber'
   gem 'webmock'


### PR DESCRIPTION
- [x] Updating `rubocop` version to `0.38.0`.
- [x] Disabling `Style/MultilineMethodCallBraceLayout` cop because who cares, amiright?