### PR TITLE
remove deprecated parameter

### DIFF
--- a/lib/twitter-ads/account.rb
+++ b/lib/twitter-ads/account.rb
@@ -204,15 +204,13 @@ module TwitterAds
 
     # Returns the most recent promotable Tweets created by one or more specified Twitter users.
     #
-    # @param ids [Array] An Array of Twitter user IDs.
     # @param opts [Hash] A Hash of extended options.
     #
     # @return [Array] An Array of Tweet objects.
     #
     # @since 0.2.3
-    def scoped_timeline(ids, opts = {})
-      ids      = ids.join(',') if ids.is_a?(Array)
-      params   = { user_ids: ids }.merge!(opts)
+    def scoped_timeline(opts = {})
+      params = opts
       resource = SCOPED_TIMELINE % { id: @id }
       request  = Request.new(client, :get, resource, params: params)
       response = request.perform


### PR DESCRIPTION
**Issue Type:**
Bug

**Fixes / Relates To:**

**Changes Included:**
- remove user_ids(deprecated)
 - https://dev.twitter.com/ads/reference/get/accounts/%3Aaccount_id/scoped_timeline

**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._

