### PR TITLE
Fix example for building and executing manual request.

### DIFF
--- a/examples/manual_request.rb
+++ b/examples/manual_request.rb
@@ -28,7 +28,7 @@ params   = { feature_keys: 'AGE_TARGETING,CPI_CHARGING' }
 
 # build and execute the request
 response = TwitterAds::Request.new(client, :get, resource, params: params).perform
-response['data'].first
+result = response.body[:data].first
 
 # you can also manually construct requests to be
 # used in TwitterAds::Cursor object.

--- a/examples/manual_request.rb
+++ b/examples/manual_request.rb
@@ -28,7 +28,7 @@ params   = { feature_keys: 'AGE_TARGETING,CPI_CHARGING' }
 
 # build and execute the request
 response = TwitterAds::Request.new(client, :get, resource, params: params).perform
-result = response.body[:data].first
+response.body[:data].first
 
 # you can also manually construct requests to be
 # used in TwitterAds::Cursor object.


### PR DESCRIPTION
**Issue Type:** Bug

**Changes Included:**

-Fix example for building and executing manual request.

**Check List:**
- [n/a ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ n/a] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [Y ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._

Need to access 'data' attribute from the body of the response, not from the response directly.
