### PR TITLE
add location_type to targeting_criteria

### DIFF
--- a/lib/twitter-ads/campaign/targeting_criteria.rb
+++ b/lib/twitter-ads/campaign/targeting_criteria.rb
@@ -22,6 +22,7 @@ module TwitterAds
     property :targeting_value
     property :tailored_audience_expansion, type: :bool
     property :tailored_audience_type
+    property :location_type
 
     RESOURCE_COLLECTION = '/1/accounts/%{account_id}/targeting_criteria'.freeze # @api private
     RESOURCE            = '/1/accounts/%{account_id}/targeting_criteria/%{id}'.freeze # @api private


### PR DESCRIPTION
**Issue Type:** Improvement

**Fixes / Relates To:** 

**Changes Included:**

- add location_type to TwitterAds::TargetingCriteria
```
twitter-ads v1.0.0 >> targeting_criteria = account.line_items(nil, campaign_ids: account.campaigns.last.id).first.targeting_criteria
=> #<TwitterAds::Cursor:0x70231733744580 count=7 fetched=7 exhausted=true>
twitter-ads v1.0.0 >> targeting_criteria.map {|item| item.location_type}
=> [nil, "REGION", nil, nil, nil, nil, nil]
```
**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._

