### PR TITLE
check_async_job_status() uses a param called job_ids, not job_id

### DIFF
--- a/lib/twitter-ads/resources/analytics.rb
+++ b/lib/twitter-ads/resources/analytics.rb
@@ -156,9 +156,9 @@ module TwitterAds
 
       def check_async_job_status(account, opts = {})
         # set default values
-        job_id = opts.fetch(:job_id, nil)
+        job_ids = opts.fetch(:job_ids, nil)
         params = {}
-        params[:job_id] = job_id if job_id
+        params[:job_ids] = Array.wrap(job_ids).join(',') if job_ids
 
         resource = self::RESOURCE_ASYNC_STATS % { account_id: account.id }
         request = Request.new(account.client, :get, resource, params: params)


### PR DESCRIPTION
**Issue Type:** Bug

**Fixes / Relates To:** #146

**Changes Included:**

- change param name from `job_id` to `job_ids`, per documentation at https://dev.twitter.com/ads/reference/1/get/stats/jobs/accounts/account_id

**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
