### PR TITLE
Ability to set UTC offsets when fetching analytics data

### DIFF
--- a/lib/twitter-ads/resources/analytics.rb
+++ b/lib/twitter-ads/resources/analytics.rb
@@ -71,12 +71,14 @@ module TwitterAds
         end_time          = opts.fetch(:end_time, (Time.now - Time.now.sec - (60 * Time.now.min)))
         start_time        = opts.fetch(:start_time, end_time - 604_800) # 7 days ago
         granularity       = opts.fetch(:granularity, :hour)
+        start_utc_offset  = opts[:start_utc_offset] || opts[:utc_offset]
+        end_utc_offset    = opts[:end_utc_offset] || opts[:utc_offset]
         placement         = opts.fetch(:placement, Placement::ALL_ON_TWITTER)
 
         params = {
           metric_groups: metric_groups.join(','),
-          start_time: TwitterAds::Utils.to_time(start_time, granularity),
-          end_time: TwitterAds::Utils.to_time(end_time, granularity),
+          start_time: TwitterAds::Utils.to_time(start_time, granularity, start_utc_offset),
+          end_time: TwitterAds::Utils.to_time(end_time, granularity, end_utc_offset),
           granularity: granularity.to_s.upcase,
           entity: ANALYTICS_MAP[name],
           placement: placement
@@ -118,6 +120,8 @@ module TwitterAds
         end_time          = opts.fetch(:end_time, (Time.now - Time.now.sec - (60 * Time.now.min)))
         start_time        = opts.fetch(:start_time, end_time - 604_800) # 7 days ago
         granularity       = opts.fetch(:granularity, :hour)
+        start_utc_offset  = opts[:start_utc_offset] || opts[:utc_offset]
+        end_utc_offset    = opts[:end_utc_offset] || opts[:utc_offset]
         placement         = opts.fetch(:placement, Placement::ALL_ON_TWITTER)
         segmentation_type = opts.fetch(:segmentation_type, nil)
         country = opts.fetch(:country, nil)
@@ -125,8 +129,8 @@ module TwitterAds
 
         params = {
           metric_groups: metric_groups.join(','),
-          start_time: TwitterAds::Utils.to_time(start_time, granularity),
-          end_time: TwitterAds::Utils.to_time(end_time, granularity),
+          start_time: TwitterAds::Utils.to_time(start_time, granularity, start_utc_offset),
+          end_time: TwitterAds::Utils.to_time(end_time, granularity, end_utc_offset),
           granularity: granularity.to_s.upcase,
           entity: ANALYTICS_MAP[name],
           placement: placement,

--- a/lib/twitter-ads/utils.rb
+++ b/lib/twitter-ads/utils.rb
@@ -27,12 +27,12 @@ module TwitterAds
       #
       # @api private
       # @since 0.1.0
-      def to_time(time, granularity = nil)
+      def to_time(time, granularity = nil, utc_offset = nil)
         return time.iso8601 unless granularity
         if granularity == :hour
-          Time.new(time.year, time.month, time.day, time.hour).iso8601
+          Time.new(time.year, time.month, time.day, time.hour, 0, 0, utc_offset).iso8601
         elsif granularity == :day
-          Time.new(time.year, time.month, time.day).iso8601
+          Time.new(time.year, time.month, time.day, 0, 0, 0, utc_offset).iso8601
         else
           time.iso8601
         end


### PR DESCRIPTION
**Issue Type:** Bug

**Fixes:** #122 

**Changes Included:**

- `TwitterAds::Utils.to_time()` needs to take a `utc_offset` param, otherwise the code only works in case the system's local timezone happens to be the same as the Twitter account's timezone
- Need to be able to pass `start_utc_offset` and `end_utc_offset` separately in case daylight saving time happens to fall in between `start_time` and `end_time`

**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
