### PR TITLE
Update analytics example to use metric groups

### DIFF
--- a/examples/analytics.rb
+++ b/examples/analytics.rb
@@ -32,7 +32,7 @@ line_items = account.line_items(nil, count: 10)[0..9]
 
 # the list of metric groups we want to fetch, for a full list of possible metrics
 # see: https://dev.twitter.com/ads/analytics/metrics-and-segmentation
-metrics = ["ENGAGEMENT", "VIDEO"]
+metrics = %W(ENGAGEMENT VIDEO)
 
 # fetching stats on the instance
 line_items.first.stats(metrics)

--- a/examples/analytics.rb
+++ b/examples/analytics.rb
@@ -32,7 +32,7 @@ line_items = account.line_items(nil, count: 10)[0..9]
 
 # the list of metric groups we want to fetch, for a full list of possible metrics
 # see: https://dev.twitter.com/ads/analytics/metrics-and-segmentation
-metrics = %W(ENGAGEMENT VIDEO)
+metrics = %w(ENGAGEMENT VIDEO)
 
 # fetching stats on the instance
 line_items.first.stats(metrics)

--- a/examples/analytics.rb
+++ b/examples/analytics.rb
@@ -30,9 +30,9 @@ account = client.accounts(ADS_ACCOUNT)
 # limit request count and grab the first 10 line items from TwitterAds::Cursor
 line_items = account.line_items(nil, count: 10)[0..9]
 
-# the list of metrics we want to fetch, for a full list of possible metrics
+# the list of metric groups we want to fetch, for a full list of possible metrics
 # see: https://dev.twitter.com/ads/analytics/metrics-and-segmentation
-metrics = [:billed_engagements, :billed_follows]
+metrics = ["ENGAGEMENT", "VIDEO"]
 
 # fetching stats on the instance
 line_items.first.stats(metrics)


### PR DESCRIPTION
**Issue Type:** Improvement

**Changes Included:**

Updated the analytics example to use metric groups. I didn't see spec coverage for the examples but let me know if I missed it.

**Check List:**

- [x] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [x] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [x] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
