### PR TITLE
Add stats resource for OrganicTweet

### DIFF
--- a/lib/twitter-ads/campaign/organic_tweet.rb
+++ b/lib/twitter-ads/campaign/organic_tweet.rb
@@ -7,6 +7,7 @@ module TwitterAds
 
     include TwitterAds::Analytics
 
+    RESOURCE_STATS       = '/1/stats/accounts/%{account_id}'.freeze # @api private
     RESOURCE_ASYNC_STATS = '/1/stats/jobs/accounts/%{account_id}'.freeze # @api private
   end
 end


### PR DESCRIPTION

**Issue Type:** Bug

**Changes Included:**

- Allows synchronous pulling of stats from an `OrganicTweet`.

**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
