### PR TITLE
Fix RESOURCE_USERS template string

### DIFF
--- a/lib/twitter-ads/audiences/tailored_audience.rb
+++ b/lib/twitter-ads/audiences/tailored_audience.rb
@@ -33,9 +33,9 @@ module TwitterAds
                            'accounts/%{account_id}/tailored_audience_changes'.freeze # @api private
     RESOURCE_MEMBERSHIPS = "/#{TwitterAds::API_VERSION}/" +
                            'tailored_audience_memberships'.freeze # @api private
-    RESOURCE_USERS       = "/#{TwitterAds::API_VERSION}/ \
-                           accounts/%{account_id}/tailored_audiences/ \
-                           %{id}/users".freeze # @api private
+    RESOURCE_USERS       = "/#{TwitterAds::API_VERSION}/" +
+                           "accounts/%{account_id}/tailored_audiences/" +
+                           "%{id}/users".freeze # @api private
     # @api private
     GLOBAL_OPT_OUT = "/#{TwitterAds::API_VERSION}/" +
                      'accounts/%{account_id}/tailored_audiences/global_opt_out'.freeze

--- a/lib/twitter-ads/audiences/tailored_audience.rb
+++ b/lib/twitter-ads/audiences/tailored_audience.rb
@@ -33,9 +33,9 @@ module TwitterAds
                            'accounts/%{account_id}/tailored_audience_changes'.freeze # @api private
     RESOURCE_MEMBERSHIPS = "/#{TwitterAds::API_VERSION}/" +
                            'tailored_audience_memberships'.freeze # @api private
-    RESOURCE_USERS       = "/#{TwitterAds::API_VERSION}/" +
-                           'accounts/%{account_id}/tailored_audiences/' +
-                           '%{id}/users'.freeze # @api private
+    RESOURCE_USERS       = ["/#{TwitterAds::API_VERSION}/",
+                            'accounts/%{account_id}/tailored_audiences/',
+                            '%{id}/users'].join.freeze # @api private
     # @api private
     GLOBAL_OPT_OUT = "/#{TwitterAds::API_VERSION}/" +
                      'accounts/%{account_id}/tailored_audiences/global_opt_out'.freeze

--- a/lib/twitter-ads/audiences/tailored_audience.rb
+++ b/lib/twitter-ads/audiences/tailored_audience.rb
@@ -34,8 +34,8 @@ module TwitterAds
     RESOURCE_MEMBERSHIPS = "/#{TwitterAds::API_VERSION}/" +
                            'tailored_audience_memberships'.freeze # @api private
     RESOURCE_USERS       = "/#{TwitterAds::API_VERSION}/" +
-                           "accounts/%{account_id}/tailored_audiences/" +
-                           "%{id}/users".freeze # @api private
+                           'accounts/%{account_id}/tailored_audiences/' +
+                           '%{id}/users'.freeze # @api private
     # @api private
     GLOBAL_OPT_OUT = "/#{TwitterAds::API_VERSION}/" +
                      'accounts/%{account_id}/tailored_audiences/global_opt_out'.freeze


### PR DESCRIPTION
The string continuation `\` includes all the indentation spaces into the resulting URL, e.g. you end up with something like this: 
```
/4/                            accounts/5678/tailored_audiences/                             54321/users
```

**Issue Type:** Bug

**Fixes / Relates To:** #183

**Changes Included:**

-
-
-

**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
