### PR TITLE
Improve Travis CI Tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 # Style & Quality Overrides
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - 'bin/**/*'
     - 'vendor/bundle/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -138,3 +138,6 @@ Layout/EmptyLineAfterMagicComment:
 
 Metrics/BlockLength:
   Enabled: false
+
+Performance/RegexpMatch:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
 language: ruby
 
-install: ruby -S bundle install --without development
+before_install:
+  - bundle config without 'development'
+
+install: bundle install
 script: bundle exec rake
 
 branches:
   only:
     - master
-    - stable
 
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx
+    - rvm: rbx-2
   include:
-    - rvm: 2.3.0
-    - rvm: 2.4.0
-    - rvm: 2.5.0
-    - rvm: 2.6.0
+    - rvm: 2.6.3
+    - rvm: 2.5.5
+    - rvm: 2.4.6
     - rvm: ruby-head
-    - rvm: rbx
+    - rvm: rbx-2

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ For more help please see our [Examples and Guides](https://github.com/twitterdev
 
 ## Compatibility & Versioning
 
-This project is designed to work with Ruby 2.3.0 or greater. While it may work on other version of Ruby, below are the platform and runtime versions we officially support and regularly test against.
+This project is designed to work with Ruby 2.4.0 or greater. While it may work on other version of Ruby, below are the platform and runtime versions we officially support and regularly test against.
 
 Platform | Versions
 -------- | --------
-MRI | 2.3.0, 2.4.x, 2.5.x, 2.6.x
+MRI | 2.4.x, 2.5.x, 2.6.x
 Rubinius | 2.4.x, 2.5.x
 
 All releases adhere to strict [semantic versioning](http://semver.org). For Example, major.minor.patch-pre (aka. stick.carrot.oops-peek).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ This project is designed to work with Ruby 2.3.0 or greater. While it may work o
 Platform | Versions
 -------- | --------
 MRI | 2.3.0, 2.4.x, 2.5.x, 2.6.x
-JRuby | 1.7.x, 9.0.0.0 (JDK7, JDK8, OpenJDK)
 Rubinius | 2.4.x, 2.5.x
 
 All releases adhere to strict [semantic versioning](http://semver.org). For Example, major.minor.patch-pre (aka. stick.carrot.oops-peek).

--- a/twitter-ads.gemspec
+++ b/twitter-ads.gemspec
@@ -33,8 +33,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'oauth', '~> 0.4'
 
-  s.add_development_dependency 'bundler', '~> 1.6'
-
   s.files = Dir.glob('{bin,lib}/**/*')
   s.files += %w(twitter-ads.gemspec LICENSE README.md CONTRIBUTING.md Rakefile)
   s.test_files = Dir.glob('{spec,feature}/**/*')

--- a/twitter-ads.gemspec
+++ b/twitter-ads.gemspec
@@ -8,14 +8,20 @@ Gem::Specification.new do |s|
   s.version     = TwitterAds::VERSION
   s.platform    = Gem::Platform::RUBY
   s.licenses    = ['MIT']
-  s.authors     = ['Brandon Black', 'John Babich', 'Jacob Petrie']
+  s.authors     = [
+    'John Babich',
+    'Tushar Bhushan',
+    'Juan Shishido',
+    'Thomas Osowski',
+    'Shohei Maeda'
+  ]
   s.email       = ['twitterdev-ads@twitter.com']
   s.homepage    = 'https://github.com/twitterdev/twitter-ruby-ads-sdk'
   s.description = 'The officially supported Twitter Ads API SDK for Ruby.'
   s.summary     = s.description
 
-  s.required_ruby_version     = '>= 2.3.0'
-  s.required_rubygems_version = '>= 2.3.0'
+  s.required_ruby_version     = '>= 2.4.0'
+  s.required_rubygems_version = '>= 2.6.0'
 
   if File.exist?('private.pem')
     s.signing_key = 'private.pem'


### PR DESCRIPTION
## Changes
- Test with stable Ruby versions (e.g., capistrano's [.travis.yml](https://github.com/capistrano/capistrano/blob/master/.travis.yml#L3-L6)).
- Change required_ruby_version to `>= 2.4.0` as Ruby 2.3 is now EOL.  
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/
- Update README.