### PR TITLE
Update URL param encoding to use CGI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (C) 2019 Twitter, Inc.
+Copyright (C) 2020 Twitter, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -17,6 +17,7 @@ module TwitterAds
     property :updated_at, type: :time, read_only: true
 
     property :advertiser_domain
+    property :android_app_store_identifier
     property :automatically_select_bid
     property :bid_amount_local_micro
     property :bid_unit
@@ -25,6 +26,7 @@ module TwitterAds
     property :charge_by
     property :end_time, type: :time
     property :entity_status
+    property :ios_app_store_identifier
     property :name
     property :objective
     property :optimization

--- a/lib/twitter-ads/http/request.rb
+++ b/lib/twitter-ads/http/request.rb
@@ -107,11 +107,17 @@ module TwitterAds
       Response.new(response.code, response.each {}, response.body)
     end
 
+    def escape_params(input)
+      input.map do |key, value|
+        "#{CGI.escape key.to_s}=#{CGI.escape value.to_s}"
+      end.join("&")
+    end
+
     def http_request
       request_url = @resource
 
       if @options[:params] && !@options[:params].empty?
-        request_url += "?#{URI.encode_www_form(@options[:params])}"
+        request_url += "?#{escape_params(@options[:params])}"
       end
 
       request      = HTTP_METHOD[@method].new(request_url)

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -2,5 +2,5 @@
 # Copyright (C) 2019 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '7.0.0'
+  VERSION = '7.0.1'
 end


### PR DESCRIPTION
**Issue Type:** Bug Fix

**Fixes / Relates To:** #123

- Relates to a [Twurl Bug Fix](https://github.com/twitter/twurl/pull/119)

**Changes Included:**

- URI.encode_www_form is deprecated and doesn't properly encode URL params to OAuth 1.0a spec.
- Updating code to use CGI.escape to properly encode URL params
- Includes fixes specified in https://github.com/twitterdev/twitter-ruby-ads-sdk/pull/228 because I'm lazy

**Check List:**

- [X] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [X] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [X] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
