### PR TITLE
Update Line Items endpoint to support new MAP parameters

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (C) 2019 Twitter, Inc.
+Copyright (C) 2020 Twitter, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -17,6 +17,7 @@ module TwitterAds
     property :updated_at, type: :time, read_only: true
 
     property :advertiser_domain
+    property :android_app_store_identifier
     property :automatically_select_bid
     property :bid_amount_local_micro
     property :bid_unit
@@ -25,6 +26,7 @@ module TwitterAds
     property :charge_by
     property :end_time, type: :time
     property :entity_status
+    property :ios_app_store_identifier
     property :name
     property :objective
     property :optimization

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -2,5 +2,5 @@
 # Copyright (C) 2019 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '7.0.0'
+  VERSION = '7.0.1'
 end


### PR DESCRIPTION
**Issue Type:** Improvement

**Changes Included:**
 
- Add `android_app_store_identifier` and `ios_app_store_identifier` per [this deprecation notice](https://twittercommunity.com/t/announcement-breaking-changes-to-mobile-app-promotion-campaigns/140794)
- Updated version and license

**Check List:**
👇 n/a
- [x] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [x] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [x] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
