### PR TITLE
Fix Github Actions CI: add rexml gem for ruby 3 & move pry gems into :test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem 'rake'
 group :development, :test do
   gem 'cucumber'
   gem 'faker', '~> 1.0'      # fix for breaking change in faker 2.x
+  gem 'pry-nav', require: true
+  gem 'pry-rescue', require: true
+  gem 'rexml'
   gem 'rspec'
   gem 'rubocop', '~> 0.50.0'
   gem 'simplecov', '~> 0.13' # fix for breaking change in simplecov
@@ -16,8 +19,6 @@ end
 group :development do
   gem 'guard-bundler', platforms: :mri
   gem 'guard-rspec', platforms: :mri
-  gem 'pry-nav', require: true
-  gem 'pry-rescue', require: true
 
   gem 'rb-fchange', require: false # Windows
   gem 'rb-fsevent', require: false # OS X


### PR DESCRIPTION
**Issue Type:** Bug

**Fixes / Relates To:**
fixes GH Actions CI gem loading bugs on `bundle exec rake` step:

```
$ bundle exec rake
WARNING:  No private key present, creating unsigned gem.
rake aborted!
LoadError: cannot load such file -- rexml/parsers/streamparser
```

as well as:
```
$ bundle exec rake
WARNING:  No private key present, creating unsigned gem.
rake aborted!
LoadError: cannot load such file -- pry-nav
```
and
```
$ bundle exec rake
WARNING:  No private key present, creating unsigned gem.
rake aborted!
LoadError: cannot load such file -- pry-rescue
twitter-ruby-ads-sdk/Rakefile:34:in `<top (required)>'
```

**Changes Included:**
`rexml`  gem was taken out of ruby in 2.8.0 (https://github.com/googleapis/google-api-ruby-client/issues/871) and ruby:head is newly released 3.0.0, which is missing that gem. Previous versions will already have gem loaded.

for the `pry-` gems:
in Rakefile for CI, bundler doesn't require :development group, so I moved the 2 pry gems into :test group.
```
if ENV['CI']
  task default: ['spec'] # 'features'
  Bundler.require(:default, :test)
```