### PR TITLE
Fix TwitterAds::Creative::PromotedTweet#save (#239)

### DIFF
--- a/lib/twitter-ads/creative/promoted_tweet.rb
+++ b/lib/twitter-ads/creative/promoted_tweet.rb
@@ -48,7 +48,7 @@ module TwitterAds
 
         # convert to `tweet_ids` param
         params = to_params
-        params[:tweet_ids] = *params.delete(:tweet_id) if params.key?(:tweet_id)
+        params[:tweet_ids] = params.delete(:tweet_id) if params.key?(:tweet_id)
 
         if @id
           raise TwitterAds::NotFound.new(nil, 'Method PUT not allowed.', 404)

--- a/spec/twitter-ads/creative/promoted_tweet_spec.rb
+++ b/spec/twitter-ads/creative/promoted_tweet_spec.rb
@@ -48,7 +48,12 @@ describe TwitterAds::Creative::PromotedTweet do
       allow(request).to receive(:perform).and_return(response)
       expected_params = { params: { line_item_id: '12345', tweet_ids: 99999999999999999999 } }
 
-      expect(Request).to receive(:new).with(client, :post, "/#{TwitterAds::API_VERSION}/accounts/#{account.id}/promoted_tweets", expected_params).and_return(request)
+      expect(Request).to receive(:new).with(
+        client,
+        :post,
+        "/#{TwitterAds::API_VERSION}/accounts/#{account.id}/promoted_tweets",
+        expected_params
+      ).and_return(request)
 
       subject.line_item_id = '12345'
       subject.tweet_id = 99999999999999999999

--- a/spec/twitter-ads/creative/promoted_tweet_spec.rb
+++ b/spec/twitter-ads/creative/promoted_tweet_spec.rb
@@ -41,7 +41,7 @@ describe TwitterAds::Creative::PromotedTweet do
       expect { subject.save }.to raise_error(TwitterAds::ClientError)
     end
 
-    it 'converts params[:tweet_id] to params[:tweet_ids]' do
+    it 'sets params[:tweet_ids] from params[:tweet_id]' do
       request = double('request')
       response = double('response')
       allow(response).to receive(:body).and_return({ data: [{}] })

--- a/spec/twitter-ads/creative/promoted_tweet_spec.rb
+++ b/spec/twitter-ads/creative/promoted_tweet_spec.rb
@@ -41,6 +41,19 @@ describe TwitterAds::Creative::PromotedTweet do
       expect { subject.save }.to raise_error(TwitterAds::ClientError)
     end
 
+    it 'converts params[:tweet_id] to params[:tweet_ids]' do
+      request = double('request')
+      response = double('response')
+      allow(response).to receive(:body).and_return({ data: [{}] })
+      allow(request).to receive(:perform).and_return(response)
+      expected_params = { params: { line_item_id: '12345', tweet_ids: 99999999999999999999 } }
+
+      expect(Request).to receive(:new).with(client, :post, "/#{TwitterAds::API_VERSION}/accounts/#{account.id}/promoted_tweets", expected_params).and_return(request)
+
+      subject.line_item_id = '12345'
+      subject.tweet_id = 99999999999999999999
+      subject.save
+    end
   end
 
 end


### PR DESCRIPTION
* Fix invalid converting params

**Issue Type:** Bug

**Fixes:** #239

**Changes Included:**

- Fix invalid converting params
- Add test code of converting params

**Check List:**

- [x] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

