### PR TITLE
Ads API v8

### DIFF
--- a/lib/twitter-ads/audiences/tailored_audience.rb
+++ b/lib/twitter-ads/audiences/tailored_audience.rb
@@ -92,7 +92,7 @@ module TwitterAds
       from_response(response.body[:data])
     end
 
-    # This is a private API and requires whitelisting from Twitter.
+    # This is a private API and requires allowlisting from Twitter.
     #
     # This endpoint will allow partners to add, update and remove users from a given
     # tailored_audience_id.
@@ -138,6 +138,60 @@ module TwitterAds
       [success_count, total_count]
     end
 
+    # Retrieves the entites targeting the current tailored audience instance.
+    #
+    # @example
+    #   audience.targeted(with_active=true)
+    #
+    # @param with_active [bool] Include active/inactive
+    #
+    # @since 8.0.0
+    #
+    # @return [self] Returns a Cursor instance of the targeted entities.
+    def targeted(opts = {})
+      validate_loaded
+      params = {}.merge!(opts)
+      TargetedTailoredAudience.load(account, id, params)
+    end
+
+    def validate_loaded
+      raise ArgumentError.new(
+        "Error! #{self.class} object not yet initialized, " \
+        "call #{self.class}.load first") if id.nil?
+    end
+  end
+
+  class TargetedTailoredAudience
+
+    include TwitterAds::DSL
+    include TwitterAds::Resource
+
+    attr_reader :account
+
+    # read-only
+    property :campaign_id, read_only: true
+    property :campaign_name, read_only: true
+    property :line_items, read_only: true
+
+    RESOURCE_TARGETED = "/#{TwitterAds::API_VERSION}/" \
+                        'accounts/%{account_id}/tailored_audiences/%{id}/targeted' # @api private
+
+    def initialize(account)
+      @account = account
+      self
+    end
+
+    class << self
+
+      def load(account, tailored_audience_id, params)
+        resource = RESOURCE_TARGETED % { account_id: account.id, id: tailored_audience_id }
+        request = TwitterAds::Request.new(account.client,
+                                          :get,
+                                          resource,
+                                          params: params)
+        Cursor.new(self, request, init_with: [account])
+      end
+    end
   end
 
   class TailoredAudiencePermission

--- a/lib/twitter-ads/client.rb
+++ b/lib/twitter-ads/client.rb
@@ -3,7 +3,7 @@
 
 module TwitterAds
 
-  API_VERSION = '7'
+  API_VERSION = '8'
 
   # The Ads API Client class which functions as a
   # container for basic API consumer information.

--- a/lib/twitter-ads/version.rb
+++ b/lib/twitter-ads/version.rb
@@ -2,5 +2,5 @@
 # Copyright (C) 2019 Twitter, Inc.
 
 module TwitterAds
-  VERSION = '7.0.1'
+  VERSION = '8.0.0'
 end

--- a/spec/fixtures/targeted_audiences.json
+++ b/spec/fixtures/targeted_audiences.json
@@ -1,0 +1,33 @@
+{
+    "request": {
+      "params": {
+        "account_id": "2iqph",
+        "tailored_audience_id": "abc2"
+      }
+    },
+    "next_cursor": null,
+    "data": [
+      {
+        "campaign_id": "59hod",
+        "campaign_name": "test-campaign",
+        "line_items": [
+          {
+            "id": "5gzog",
+            "name": "test-line-item",
+            "servable": true
+          }
+        ]
+      },
+      {
+        "campaign_id": "arja7",
+        "campaign_name": "Untitled campaign",
+        "line_items": [
+          {
+            "id": "bjw1q",
+            "name": null,
+            "servable": true
+          }
+        ]
+      }
+    ]
+}  

--- a/spec/twitter-ads/audiences/tailored_audience_spec.rb
+++ b/spec/twitter-ads/audiences/tailored_audience_spec.rb
@@ -7,7 +7,13 @@ describe TwitterAds::TailoredAudience do
 
   before(:each) do
     stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
-    stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+    # stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
+    stub_fixture(:get,
+                 :tailored_audiences_load,
+                 "#{ADS_API}/accounts/2iqph/tailored_audiences/abc2?with_deleted=true")
+    stub_fixture(:get,
+                 :targeted_audiences,
+                 "#{ADS_API}/accounts/2iqph/tailored_audiences/abc2/targeted")
   end
 
   let(:client) do
@@ -20,7 +26,7 @@ describe TwitterAds::TailoredAudience do
   end
 
   let(:account) { client.accounts.first }
-
+  let(:tailored_audience) { described_class.load(account, 'abc2') }
   # check model properties
   subject { described_class.new(account) }
 
@@ -43,4 +49,21 @@ describe TwitterAds::TailoredAudience do
 
   include_examples 'object property check', read, write
 
+  describe '#targeted' do
+
+    let(:cursor) { tailored_audience.targeted }
+
+    it 'has all the correct properties' do
+      result = cursor.first
+      expect(result).to eq(cursor.instance_variable_get('@collection').first)
+      expect(result).to be_instance_of(TwitterAds::TargetedTailoredAudience)
+      expect(cursor).to be_instance_of(Cursor)
+    end
+
+    it 'raises error when TailoredAudience is not loaded' do
+      result = TwitterAds::TailoredAudience.new(account)
+      expect(result).to receive(:validate_loaded).and_call_original
+      expect { result.targeted }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/twitter-ads/audiences/tailored_audience_spec.rb
+++ b/spec/twitter-ads/audiences/tailored_audience_spec.rb
@@ -7,7 +7,6 @@ describe TwitterAds::TailoredAudience do
 
   before(:each) do
     stub_fixture(:get, :accounts_all, "#{ADS_API}/accounts")
-    # stub_fixture(:get, :accounts_load, "#{ADS_API}/accounts/2iqph")
     stub_fixture(:get,
                  :tailored_audiences_load,
                  "#{ADS_API}/accounts/2iqph/tailored_audiences/abc2?with_deleted=true")


### PR DESCRIPTION
**Issue Type:** Bug, Improvement or Feature (Select One)

**Fixes / Relates To:** #123

**Changes Included:**

Details for v8 release can be found [here](https://twittercommunity.com/t/ads-api-version-8/141914/2)

Changes included:
* Renamed objective enums
* Added targeted audiences support + tests
* Updated examples
* `owner_account_id` for Tailored Audiences

**Check List:**

- [x] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.