### PR TITLE
Updates to switch to ios for Cards

### DIFF
--- a/lib/twitter-ads/account.rb
+++ b/lib/twitter-ads/account.rb
@@ -10,7 +10,6 @@ module TwitterAds
 
     property :id, read_only: true
     property :name, read_only: true
-    property :salt, read_only: true
     property :timezone, read_only: true
     property :timezone_switch_at, type: :time, read_only: true
     property :created_at, type: :time, read_only: true

--- a/lib/twitter-ads/creative/cards_fetch.rb
+++ b/lib/twitter-ads/creative/cards_fetch.rb
@@ -35,10 +35,8 @@ module TwitterAds
       property :image, read_only: true
       property :image_display_height, read_only: true
       property :image_display_width, read_only: true
-      property :ipad_app_id, read_only: true
-      property :ipad_deep_link, read_only: true
-      property :iphone_app_id, read_only: true
-      property :iphone_deep_link, read_only: true
+      property :ios_app_store_identifier, read_only: true
+      property :ios_deep_link, read_only: true
       property :name, read_only: true
       property :recipient_user_id, read_only: true
       property :second_choice, read_only: true

--- a/lib/twitter-ads/creative/image_app_download_card.rb
+++ b/lib/twitter-ads/creative/image_app_download_card.rb
@@ -26,10 +26,8 @@ module TwitterAds
       property :app_cta
       property :googleplay_app_id
       property :googleplay_deep_link
-      property :iphone_app_id
-      property :iphone_deep_link
-      property :ipad_app_id
-      property :ipad_deep_link
+      property :ios_app_store_identifier
+      property :ios_deep_link
       property :name
       property :media_key
 

--- a/lib/twitter-ads/creative/video_app_download_card.rb
+++ b/lib/twitter-ads/creative/video_app_download_card.rb
@@ -25,10 +25,8 @@ module TwitterAds
       property :country_code
       property :app_cta
       property :poster_media_key
-      property :ipad_app_id
-      property :ipad_deep_link
-      property :iphone_app_id
-      property :iphone_deep_link
+      property :ios_app_store_identifier
+      property :ios_deep_link
       property :googleplay_app_id
       property :googleplay_deep_link
       property :name

--- a/lib/twitter-ads/enum.rb
+++ b/lib/twitter-ads/enum.rb
@@ -84,6 +84,7 @@ module TwitterAds
 
     module PayBy
       APP_CLICK = 'APP_CLICK'
+      IMPRESSION = 'IMPRESSION'
     end
 
     module MetricGroup

--- a/spec/fixtures/accounts_all.json
+++ b/spec/fixtures/accounts_all.json
@@ -9,7 +9,6 @@
       "timezone_switch_at": "2014-11-17T08:00:00Z",
       "id": "2iqph",
       "created_at": "2015-03-04T10:50:42Z",
-      "salt": "5ab2pizq7qxjjqrx3z67f4wbko61o7xs",
       "updated_at": "2015-04-11T05:20:08Z",
       "approval_status": "ACCEPTED",
       "deleted": false
@@ -20,7 +19,6 @@
       "timezone_switch_at": "2014-11-17T08:00:00Z",
       "id": "pz6ec",
       "created_at": "2015-05-29T00:52:16Z",
-      "salt": "39ku32xvhdt0jax8thps2c70e2fv3yok",
       "updated_at": "2015-05-29T00:52:16Z",
       "approval_status": "ACCEPTED",
       "deleted": false
@@ -31,7 +29,6 @@
       "timezone_switch_at": "2014-11-17T08:00:00Z",
       "id": "j9ozo",
       "created_at": "2015-05-01T12:08:10Z",
-      "salt": "winwfne3y6oyikl4tm84bj9r50waxj37",
       "updated_at": "2015-05-01T12:08:10Z",
       "approval_status": "ACCEPTED",
       "deleted": false
@@ -42,7 +39,6 @@
       "timezone_switch_at": "2014-11-17T08:00:00Z",
       "id": "9ttgd",
       "created_at": "2015-06-24T18:51:20Z",
-      "salt": "tj9hmt5xylm5zztrq05w7hwh4mkpkg5r",
       "updated_at": "2015-06-26T06:13:24Z",
       "approval_status": "ACCEPTED",
       "deleted": false
@@ -53,7 +49,6 @@
       "timezone_switch_at": "2013-05-22T07:00:00Z",
       "id": "47d0v",
       "created_at": "2015-05-28T05:42:03Z",
-      "salt": "1ms1mq1nww7zl7169865gwqt89s9127m",
       "updated_at": "2015-05-28T05:42:03Z",
       "approval_status": "ACCEPTED",
       "deleted": false

--- a/spec/fixtures/accounts_load.json
+++ b/spec/fixtures/accounts_load.json
@@ -6,7 +6,6 @@
     "timezone_switch_at": "2014-11-17T08:00:00Z",
     "id": "2iqph",
     "created_at": "2015-03-04T10:50:42Z",
-    "salt": "5ab2pizq7qxjjqrx3z67f4wbko61o7xs",
     "updated_at": "2015-04-11T05:20:08Z",
     "approval_status": "ACCEPTED",
     "deleted": false


### PR DESCRIPTION
We recently introduced a validation rule that requires a match between the ids set on the creative level and those on the line_item level.

With that, we have made a change to help avoid any issues with the validation rule by reducing the parameters available. Specifically:

* For App Cards:
  * Deprecated `ipad_app_id` parameter
  * Renamed `iphone_app_id` to `ios_app_store_identifier` parameters
* Renamed `iphone_deep_link` to `ios_deep_link`
* Moving forward, switch to `ios_app_store_identifier` to align with the `line_item` field naming.

This update was related to the [Line Item/Ad Group Mobile App Promotion changes](https://twittercommunity.com/t/ads-api-version-9/150316#line-itemad-group-mobile-app-promotion-changes-5) introduced in v9.