### PR TITLE
Ruby 3.0.0 Compatibility

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: [2.7, 2.6.4, 2.5.6, 2.4.7]
+        ruby_version: [3.0, 2.7, 2.6.4, 2.5.6, 2.4.7]
         os: [ubuntu, macos]
          
     steps:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This project is designed to work with Ruby 2.4.0 or greater. While it may work o
 
 Platform | Versions
 -------- | --------
-MRI | 2.4.x, 2.5.x, 2.6.x
+MRI | 2.4.x, 2.5.x, 2.6.x, 2.7, 3.0
 Rubinius | 2.4.x, 2.5.x
 
 All releases adhere to strict [semantic versioning](http://semver.org). For Example, major.minor.patch-pre (aka. stick.carrot.oops-peek).
@@ -89,7 +89,7 @@ Like the [Response](https://github.com/twitterdev/twitter-ruby-ads-sdk/blob/mast
 
 The MIT License (MIT)
 
-Copyright (C) 2019 Twitter, Inc.
+Copyright (C) 2021 Twitter, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/twitter-ads/cursor.rb
+++ b/lib/twitter-ads/cursor.rb
@@ -56,13 +56,13 @@ module TwitterAds
     # @return [Cursor] The current Cursor instance.
     #
     # @since 0.1.0
-    def each(offset = 0)
+    def each(offset = 0, &block)
       return to_enum(:each, offset) unless block_given?
       @collection[offset..-1].each { |element| yield(element) }
       unless exhausted?
         offset = [@collection.size, offset].max
         fetch_next
-        each(offset, &Proc.new)
+        each(offset, &block)
       end
       self
     end

--- a/lib/twitter-ads/resources/analytics.rb
+++ b/lib/twitter-ads/resources/analytics.rb
@@ -211,7 +211,7 @@ module TwitterAds
         tries = 0
         begin
           tries += 1
-          raw_file = open(data_url)
+          raw_file = URI.open(data_url)
           unzipped_file = Zlib::GzipReader.new(raw_file)
           response_data = unzipped_file.read
           response = JSON.parse(response_data)


### PR DESCRIPTION
**Issue Type:** Feature 

**Fixes / Relates To:** #258 Add support for Ruby 3

**Changes Included:**
- Change &Proc.new to &block (#253)

**Check List:**

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).

_For more information on check list items, please see the [Contributors Guide](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/CONTRIBUTING.md)._
