### PR TITLE
Add name property to draft tweets

### DIFF
--- a/lib/twitter-ads/creative/draft_tweet.rb
+++ b/lib/twitter-ads/creative/draft_tweet.rb
@@ -24,6 +24,7 @@ module TwitterAds
       property :media_keys
       property :nullcast, type: :bool
       property :text
+      property :name
 
       RESOURCE_COLLECTION = "/#{TwitterAds::API_VERSION}/" \
                             'accounts/%{account_id}/draft_tweets' # @api private


### PR DESCRIPTION
**Issue Type:** Improvement

**Changes Included:**

- Add the property ``name`` to ``DraftTweet`` that was missing