### PR TITLE
add Japan-target age buckets

### DIFF
--- a/lib/twitter-ads/enum.rb
+++ b/lib/twitter-ads/enum.rb
@@ -174,6 +174,19 @@ module TwitterAds
       AGE_35_TO_54 = 'AGE_35_TO_54'
       AGE_OVER_35  = 'AGE_OVER_35'
       AGE_OVER_50  = 'AGE_OVER_50'
+      AGE_13_TO_19 = 'AGE_13_TO_19'
+      AGE_13_TO_29 = 'AGE_13_TO_29'
+      AGE_13_TO_39 = 'AGE_13_TO_39'
+      AGE_20_TO_29 = 'AGE_20_TO_29'
+      AGE_20_TO_34 = 'AGE_20_TO_34'
+      AGE_20_TO_39 = 'AGE_20_TO_39'
+      AGE_20_TO_49 = 'AGE_20_TO_49'
+      AGE_OVER_20 = 'AGE_OVER_20'
+      AGE_30_TO_39 = 'AGE_30_TO_39'
+      AGE_30_TO_49 = 'AGE_30_TO_49'
+      AGE_OVER_30 = 'AGE_OVER_30'
+      AGE_40_TO_49 = 'AGE_40_TO_49'
+      AGE_OVER_40 = 'AGE_OVER_40'
     end
 
     module Events


### PR DESCRIPTION
**Issue Type:** Improvement

**Relates To:** #266 

**Changes Included:**

- Add some values to agebuckets enum. [Japan-target only age buckets](https://twittercommunity.com/t/announcement-new-japan-age-targeting-buckets/103930)


**Check List:**
No changes to tests or examples.

- [ ] Includes adequate test [coverage](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/spec) for changes made.
- [ ] Includes new or updated [documentation](http://twitterdev.github.io/twitter-ruby-ads-sdk/reference/index.html).
- [ ] Includes new or updated usage [examples](https://github.com/twitterdev/twitter-ruby-ads-sdk/tree/master/examples).
