### PR TITLE
Adds Video and Image diemensions field in respective class

### DIFF
--- a/lib/twitter-ads/creative/image_conversation_card.rb
+++ b/lib/twitter-ads/creative/image_conversation_card.rb
@@ -35,6 +35,8 @@ module TwitterAds
       property :third_cta
       property :third_cta_tweet
       property :title
+      property :image_display_height
+      property :image_display_width
 
       RESOURCE_COLLECTION = "/#{TwitterAds::API_VERSION}/" \
                             'accounts/%{account_id}/cards/image_conversation' # @api private

--- a/lib/twitter-ads/creative/video_conversation_card.rb
+++ b/lib/twitter-ads/creative/video_conversation_card.rb
@@ -37,6 +37,8 @@ module TwitterAds
       property :third_cta_tweet
       property :title
       property :media_key
+      property :video_width
+      property :video_height
 
       RESOURCE_COLLECTION = "/#{TwitterAds::API_VERSION}/" \
                             'accounts/%{account_id}/cards/video_conversation' # @api private


### PR DESCRIPTION
Both classes ImageConversationCard and VideoConversationCard have field which have data related to dimensions/size of Video/Image but these fields despite present in API are being dropped/ignored in class properties/attributes, thus consumer of this library can't assess data like 'image_display_height' on ImageConversationCard till now. Current fix enable the same for both Image and Video Conversation Card.

**Issue Type:** Improvement

**Fixes / Relates To:** #273

**Changes Included:**

- Adding two properties `image_display_height` and `image_display_width` in `ImageConversationCard` class
- Adding two properties `video_width` and `video_height` in `VideoConversationCard` class